### PR TITLE
Update README to specify exact STA Version needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FROST-Benchmark
 
-A set of tools to run load-tests on a SensorThings API compatible service.
+A set of tools to run load-tests on a service implementing [SensorThingsAPI Version 1.1 Draft](https://portal.ogc.org/files/92752).
 
 ## Use
 


### PR DESCRIPTION
The Iot-Benchmark Implementation relies on features only present in the latest Draft of the STA v1.1 Specification, e.g. Datastreams->properties (not existent in STA 1.0) is used for filtering here:

https://github.com/SpeckiJ/IoT-Benchmark/blob/205e01aa1ac2f98ef059f6254a5e5c3d3589d1c3/BenchmarkData/src/main/java/de/fraunhofer/iosb/ilt/frostBenchmark/BenchData.java#L188

This PR just updates the README to specify what version is needed, as "SensorThings API compatible service" could also refer to the already release STA Version 1.0 Specification